### PR TITLE
Fixed IO Crash, experimental fix for failed stat generation

### DIFF
--- a/extension/slippi.js
+++ b/extension/slippi.js
@@ -375,6 +375,7 @@ async function connectToSlippi(type = "dolphin", address = "0.0.0.0", slpPort = 
 
 		let pathExtras = [];
 
+		/* This currently causes an IO Exception
 		if (tournament.value.name && tournament.value.name.length > 0) {
 			pathExtras.push(tournament.value.name);
 
@@ -395,6 +396,7 @@ async function connectToSlippi(type = "dolphin", address = "0.0.0.0", slpPort = 
 				}
 			}
 		}
+		*/
 
 		//Sanitize the extra paths before creating the directory
 		for (let n = 0; n < pathExtras.length; n++) {
@@ -425,6 +427,8 @@ async function connectToSlippi(type = "dolphin", address = "0.0.0.0", slpPort = 
 				if (fs.existsSync(filePath)) {
 					fs.renameSync(filePath, finalPathCombined);
 					gotSLPFile = true;
+					//There seems to be a race condition, that sometimes causes the stat generation to fail without this wait #notsure
+					await waitFor(3);
 					break;
 				}
 				else {


### PR DESCRIPTION
Quick fixed IO Crash that happens due one of the libs trying to access the dumped slp in it's initial path. slp file will stay in it's initial dump location.
Experimental fix for failed stat generation.